### PR TITLE
multi-pod log command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 )
 
 var cfgFile string
+var namespaceFlag string
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -59,6 +60,8 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	RootCmd.PersistentFlags().StringVar(&namespaceFlag, "namespace", "", "namespace containing target")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Initial pass at a multi-pod log retrieval command.

Supports: 
- `namespace`
- tail
- container

Pod matching based on a given, comma-separated label selector.
